### PR TITLE
Switch index back to ES5 to fix consumption by ESLint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 import {rule as noArrayRender} from './rules/no-array-render'
 
-export default {
+module.exports = {
   configs: {
     recommended: {
       rules: {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

*   [ ] #none# - documentation fixes and/or test additions
*   [x] #patch# - backwards-compatible bug fix
*   [ ] #minor# - adding functionality in a backwards-compatible manner
*   [ ] #major# - incompatible API change

# CHANGELOG

*   Changed `index.js` back to ES5 to fix consumption by ESLint.
